### PR TITLE
Use updated top and left when aligning tooltips.

### DIFF
--- a/lib/modules/tooltip.js
+++ b/lib/modules/tooltip.js
@@ -125,12 +125,15 @@ const positionTooltip = (element, target, alignment, offset) => {
     const heightLimit = self.innerHeight - offset;
     const widthLimit = self.innerWidth - offset;
 
-    element.style.top = top > offset ? top : offset;
-    element.style.bottom = top + elementHeight > heightLimit ? offset : null;
-    element.style.height = top + elementHeight > heightLimit ? 'auto' : element.style.height;
-    element.style.left = left > offset ? left : offset;
-    element.style.right = left + elementWidth > widthLimit ? offset : null;
-    element.style.width = left + elementWidth > widthLimit ? 'auto' : element.style.width;
+    const newTop = top > offset ? top : offset;
+    element.style.top = newTop;
+    element.style.bottom = newTop + elementHeight > heightLimit ? offset : null;
+    element.style.height = newTop + elementHeight > heightLimit ? 'auto' : element.style.height;
+
+    const newLeft = left > offset ? left : offset;
+    element.style.left =  newLeft;
+    element.style.right = newLeft + elementWidth > widthLimit ? offset : null;
+    element.style.width = newLeft + elementWidth > widthLimit ? 'auto' : element.style.width;
 
     // Finnaly, position the arrow div within the tooltip
     Array

--- a/tooltip.js
+++ b/tooltip.js
@@ -237,12 +237,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var heightLimit = self.innerHeight - offset;
 	      var widthLimit = self.innerWidth - offset;
 
-	      element.style.top = top > offset ? top : offset;
-	      element.style.bottom = top + elementHeight > heightLimit ? offset : null;
-	      element.style.height = top + elementHeight > heightLimit ? 'auto' : element.style.height;
-	      element.style.left = left > offset ? left : offset;
-	      element.style.right = left + elementWidth > widthLimit ? offset : null;
-	      element.style.width = left + elementWidth > widthLimit ? 'auto' : element.style.width;
+	      var newTop = top > offset ? top : offset;
+	      element.style.top = newTop;
+	      element.style.bottom = newTop + elementHeight > heightLimit ? offset : null;
+	      element.style.height = newTop + elementHeight > heightLimit ? 'auto' : element.style.height;
+
+	      var newLeft = left > offset ? left : offset;
+	      element.style.left = newLeft;
+	      element.style.right = newLeft + elementWidth > widthLimit ? offset : null;
+	      element.style.width = newLeft + elementWidth > widthLimit ? 'auto' : element.style.width;
 
 	      // Finnaly, position the arrow div within the tooltip
 	      Array.from(element.children).slice(0, 2).map(function (x, i) {


### PR DESCRIPTION
This fixes bugs with tooltips that were being rendered partially offscreen. Tooltips position themselves based on content size and offset. Part of the alignment pass ensures content is onscreen after centering it against the tooltip target. There was a bug that prevented the right and bottom from using the 'normalized' left and top.

👓  @nramadas 
