### PR TITLE
Import PropTypes from prop-types package

### DIFF
--- a/lib/modules/modal.js
+++ b/lib/modules/modal.js
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-const T = React.PropTypes;
+const T = PropTypes;
 
 const STYLE_CONTAINER = {
   position: 'fixed',

--- a/lib/modules/scroller.js
+++ b/lib/modules/scroller.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import raf from 'raf';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { debounce } from 'lodash/function';
 
-const T = React.PropTypes;
+const T = PropTypes;
 
 const STYLE = {
   position: 'relative',

--- a/lib/modules/tooltip.js
+++ b/lib/modules/tooltip.js
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { values } from 'lodash/object';
 
-const T = React.PropTypes;
+const T = PropTypes;
 
 const TOOLTIP_ALIGNMENT = {
   ABOVE: 'above',
@@ -244,7 +245,7 @@ export class _Tooltip extends React.Component {
       return null;
     }
   }
-};
+}
 
 export class _TooltipTarget extends React.Component {
   static propTypes = {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
   "homepage": "https://github.com/nramadas/r-widgets#readme",
   "peerDependencies": {
     "lodash": "^4.x",
+    "prop-types": "^15.5.10",
+    "raf": "^3.x",
     "react": "^15.x",
     "react-redux": "^4.x",
     "redux": "^3.x",
-    "reselect": "^2.x",
-    "raf": "^3.x"
+    "reselect": "^2.x"
   },
   "devDependencies": {
     "babel-core": "^6.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@r/widgets",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A collection of React components and the Redux actions and reducers to accompany them",
   "main": "widgets.js",
   "scripts": {


### PR DESCRIPTION
This change uses react-codemod to transform our PropTypes import out of React.

Required for React 16.